### PR TITLE
Restore resources after reload

### DIFF
--- a/src/main/java/dev/xkmc/lpcore/client/WrappedResourceManager.java
+++ b/src/main/java/dev/xkmc/lpcore/client/WrappedResourceManager.java
@@ -80,6 +80,7 @@ public class WrappedResourceManager extends ReloadableResourceManager {
 		LPClientTracker.fillReport(totalTime, noTaskTime.get() / 1000000, ans);
 		var vanilla = new ReloadableResourceManager(PackType.CLIENT_RESOURCES);
 		Minecraft.getInstance().resourceManager = vanilla;
+		vanilla.resources = this.resources;
 		vanilla.listeners.addAll(ACTUAL);
 	}
 

--- a/src/main/java/dev/xkmc/lpcore/client/WrappedResourceManager.java
+++ b/src/main/java/dev/xkmc/lpcore/client/WrappedResourceManager.java
@@ -78,7 +78,7 @@ public class WrappedResourceManager extends ReloadableResourceManager {
 			ans.add(e.getReport());
 		}
 		LPClientTracker.fillReport(totalTime, noTaskTime.get() / 1000000, ans);
-		var vanilla = new ReloadableResourceManager(PackType.CLIENT_RESOURCES);
+		var vanilla = new ReloadableResourceManager(this.type);
 		Minecraft.getInstance().resourceManager = vanilla;
 		vanilla.resources = this.resources;
 		vanilla.listeners.addAll(ACTUAL);

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,2 +1,3 @@
 public-f net.minecraft.client.Minecraft f_91036_ # resourceManager
 public net.minecraft.server.packs.resources.ReloadableResourceManager f_203816_ # listeners
+public net.minecraft.server.packs.resources.ReloadableResourceManager f_203815_ # resources

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,3 +1,4 @@
 public-f net.minecraft.client.Minecraft f_91036_ # resourceManager
 public net.minecraft.server.packs.resources.ReloadableResourceManager f_203816_ # listeners
 public net.minecraft.server.packs.resources.ReloadableResourceManager f_203815_ # resources
+protected net.minecraft.server.packs.resources.ReloadableResourceManager f_203817_ # type


### PR DESCRIPTION
Once resources are done reloading, the loading profiler core hands vanilla a new resource manager so that it doesn't get tracked. Unfortunately, this new resource manager doesn't have any of the resources that were used in the wrapped resource manager. This breaks any mods that attempt to use the resource manager after resources are reloaded.

This PR fixes that issue by copying the resources from the wrapped manager to the new one that is given to vanilla on closure.